### PR TITLE
 Update deprecated syntax for future rstan compatibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,7 +41,7 @@ Imports:
     methods,
     Rcpp (>= 0.12.0),
     RcppParallel,
-    rstan (>= 2.18.1),
+    rstan (>= 2.26.0),
     rstantools (>= 2.1.1),
     stats
 LinkingTo: 
@@ -49,8 +49,8 @@ LinkingTo:
     Rcpp (>= 0.12.0),
     RcppEigen (>= 0.3.3.3.0),
     RcppParallel,
-    rstan (>= 2.18.1),
-    StanHeaders (>= 2.18.0)
+    rstan (>= 2.26.0),
+    StanHeaders (>= 2.26.0)
 SystemRequirements: GNU make
 URL: https://github.com/zhengxiaoUVic/rmBayes
 BugReports: https://github.com/zhengxiaoUVic/rmBayes/issues

--- a/inst/stan/HDIc.stan
+++ b/inst/stan/HDIc.stan
@@ -1,7 +1,7 @@
 data {
   int<lower=1> N;        // number of subjects
   int<lower=2> C;        // number of conditions
-  vector[C] Y[N];        // responses
+  array[N] vector[C] Y;        // responses
   real tcrit;            // critical value
   real<lower=0> hb;      // (square root) scale parameter of the standardized subject-specific random effects
 }

--- a/inst/stan/HDIcCauchy.stan
+++ b/inst/stan/HDIcCauchy.stan
@@ -1,7 +1,7 @@
 data {
   int<lower=1> N;        // number of subjects
   int<lower=2> C;        // number of conditions
-  vector[C] Y[N];        // responses
+  array[N] vector[C] Y;        // responses
   real tcrit;            // critical value
 }
 

--- a/inst/stan/HDIcUnif.stan
+++ b/inst/stan/HDIcUnif.stan
@@ -1,7 +1,7 @@
 data {
   int<lower=1> N;        // number of subjects
   int<lower=2> C;        // number of conditions
-  vector[C] Y[N];        // responses
+  array[N] vector[C] Y;        // responses
   real tcrit;            // critical value
 }
 

--- a/inst/stan/HDId.stan
+++ b/inst/stan/HDId.stan
@@ -1,7 +1,7 @@
 data {
   int<lower=1> N;        // number of subjects
   int<lower=2> C;        // number of conditions
-  vector[C] Y[N];        // responses
+  array[N] vector[C] Y;        // responses
   real tcrit;            // critical value
   real<lower=0> ht;      // (square root) scale parameter of the standardized treatment effects
   real<lower=0> hb;      // (square root) scale parameter of the standardized subject-specific random effects

--- a/inst/stan/HDIdCauchy.stan
+++ b/inst/stan/HDIdCauchy.stan
@@ -1,7 +1,7 @@
 data {
   int<lower=1> N;        // number of subjects
   int<lower=2> C;        // number of conditions
-  vector[C] Y[N];        // responses
+  array[N] vector[C] Y;        // responses
   real tcrit;            // critical value
 }
 

--- a/inst/stan/HDIdCauchyFixed.stan
+++ b/inst/stan/HDIdCauchyFixed.stan
@@ -1,7 +1,7 @@
 data {
   int<lower=1> N;        // number of subjects
   int<lower=2> C;        // number of conditions
-  vector[C] Y[N];        // responses
+  array[N] vector[C] Y;        // responses
   real tcrit;            // critical value
   matrix[C,C-1] Q;       // projecting C fixed effects into C-1
 }

--- a/inst/stan/HDIdFixed.stan
+++ b/inst/stan/HDIdFixed.stan
@@ -1,7 +1,7 @@
 data {
   int<lower=1> N;        // number of subjects
   int<lower=2> C;        // number of conditions
-  vector[C] Y[N];        // responses
+  array[N] vector[C] Y;        // responses
   real tcrit;            // critical value
   matrix[C,C-1] Q;       // projecting C fixed effects into C-1
   real<lower=0> ht;      // (square root) scale parameter of the standardized treatment effects

--- a/inst/stan/HDIdUnif.stan
+++ b/inst/stan/HDIdUnif.stan
@@ -1,7 +1,7 @@
 data {
   int<lower=1> N;        // number of subjects
   int<lower=2> C;        // number of conditions
-  vector[C] Y[N];        // responses
+  array[N] vector[C] Y;        // responses
   real tcrit;            // critical value
 }
 

--- a/inst/stan/HDIdUnifFixed.stan
+++ b/inst/stan/HDIdUnifFixed.stan
@@ -1,7 +1,7 @@
 data {
   int<lower=1> N;        // number of subjects
   int<lower=2> C;        // number of conditions
-  vector[C] Y[N];        // responses
+  array[N] vector[C] Y;        // responses
   real tcrit;            // critical value
   matrix[C,C-1] Q;       // projecting C fixed effects into C-1
 }

--- a/inst/stan/HDIstandard.stan
+++ b/inst/stan/HDIstandard.stan
@@ -2,7 +2,7 @@ data {
   int<lower=1> N;        // total number of subjects
   int<lower=2> C;        // number of conditions
   vector[N] Y;           // responses (ready for the ragged data structure)
-  int s[C];              // condition sizes
+  array[C] int s;              // condition sizes
   real<lower=0> ht;      // (square root) scale parameter of the standardized treatment effects
 }
 

--- a/inst/stan/HDIstandardFixed.stan
+++ b/inst/stan/HDIstandardFixed.stan
@@ -2,7 +2,7 @@ data {
   int<lower=1> N;        // total number of subjects
   int<lower=2> C;        // number of conditions
   vector[N] Y;           // responses (ready for the ragged data structure)
-  int s[C];              // condition sizes
+  array[C] int s;              // condition sizes
   matrix[C,C-1] Q;       // projecting C fixed effects into C-1
   real<lower=0> ht;      // (square root) scale parameter of the standardized treatment effects
 }

--- a/inst/stan/HDIstandardHetero.stan
+++ b/inst/stan/HDIstandardHetero.stan
@@ -2,7 +2,7 @@ data {
   int<lower=1> N;        // total number of subjects
   int<lower=2> C;        // number of conditions
   vector[N] Y;           // responses (ready for the ragged data structure)
-  int s[C];              // condition sizes
+  array[C] int s;              // condition sizes
   real tcrit;            // critical value
   real<lower=0> ht;      // (square root) scale parameter of the standardized treatment effects
 }


### PR DESCRIPTION
Now that rstan 2.26 is available on CRAN we need to update the deprecated syntax in your package's Stan models, otherwise it will fail to install with an upcoming version of RStan. 

The following updates have been made:

- New array syntax

More information about the deprecated and removed syntax in Stan can be found here:
- https://mc-stan.org/docs/functions-reference/deprecated-functions.html
- https://mc-stan.org/docs/functions-reference/removed-functions.html

If you could merge and submit to CRAN soon, it would be greatly appreciated.

Let me know if you have any questions about these changes.

Thanks!
